### PR TITLE
fix(builder): add argument to ExtractResources.sh so files get extracted

### DIFF
--- a/builder/entrypoint.sh
+++ b/builder/entrypoint.sh
@@ -73,7 +73,7 @@ function extract_resources_from_client()
     cp * "${HOME_DIR}/wow-client/"
     cd "${HOME_DIR}/wow-client"
 
-    ./ExtractResources.sh
+    ./ExtractResources.sh a
 
     mv Cameras "${VOLUME_DIR}/Cameras"
     mv dbc "${VOLUME_DIR}/dbc"


### PR DESCRIPTION
This issue fixes 
- #15 

by adding the `a` option to extract all files.

See [ExtractResources.sh](https://github.com/cmangos/mangos-tbc/blob/ea5fd3b73bb9312b2f88b18ec385442962f752c0/contrib/extractor_scripts/ExtractResources.sh#L13)

Tested locally on my end with success