### PR TITLE
fix(runner): improve config merging logic to prevent overwriting specific settings

### DIFF
--- a/runner/entrypoint.sh
+++ b/runner/entrypoint.sh
@@ -11,7 +11,12 @@ function _replace_conf()
     local REPLACE_WITH="${2}"
     local FILENAME="${3}"
 
-    sed -i "/^${SEARCH_FOR}/c\\${SEARCH_FOR} = ${REPLACE_WITH}" "${FILENAME}"
+    if grep -q "^${SEARCH_FOR}[[:space:]]*=" "${FILENAME}"
+    then
+        sed -i "s|^${SEARCH_FOR}[[:space:]]*=.*|${SEARCH_FOR} = ${REPLACE_WITH}|" "${FILENAME}"
+    else
+        echo "${SEARCH_FOR} = ${REPLACE_WITH}" >> "${FILENAME}"
+    fi
 }
 function _merge_confs()
 {
@@ -22,7 +27,7 @@ function _merge_confs()
     do
         PROPERTY="$(echo "${LINE}" | cut -d '#' -f 1 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
 
-        if [[ -n "${PROPERTY}" ]]
+        if [[ -n "${PROPERTY}" && "${PROPERTY}" == *"="* ]]
         then
             local SEARCH_FOR="$(echo "${PROPERTY}" | cut -d '=' -f 1 | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
             local REPLACE_WITH="$(echo "${PROPERTY}" | cut -d '=' -f 2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
@@ -66,6 +71,18 @@ function compose_realmd_conf()
         _merge_confs realmd.conf "/opt/mangos/conf/realmd.conf"
     fi
 }
+function compose_aiplayerbot_conf()
+{
+    cd "${MANGOS_DIR}/etc"
+    if [[ -f "aiplayerbot.conf.dist" ]]
+    then
+        cp aiplayerbot.conf.dist aiplayerbot.conf
+        if [[ -f "/opt/mangos/conf/aiplayerbot.conf" ]]
+        then
+            _merge_confs aiplayerbot.conf "/opt/mangos/conf/aiplayerbot.conf"
+        fi
+    fi
+}
 
 function set_timezone()
 {
@@ -88,6 +105,7 @@ function init_runner()
 
     compose_mangosd_conf
     compose_realmd_conf
+    compose_aiplayerbot_conf
 }
 
 function run_mangosd()


### PR DESCRIPTION
If not applied changes like `Rate.XP.Kill.Vanilla` are interpreted as `Rate.XP.Kill` so 4th lvl nested items doesnt work

In the official repository's runner/entrypoint.sh (https://github.com/Byloth/cmangos-docker/blob/master/runner/entrypoint.sh), the function is defined as:

   1 function _replace_conf()
   2 {
   3     local SEARCH_FOR="${1}"
   4     local REPLACE_WITH="${2}"
   5     local FILENAME="${3}"
   6
   7     sed -i "/^${SEARCH_FOR}/c\\${SEARCH_FOR} = ${REPLACE_WITH}" "${FILENAME}"
   8 }

  Why this is a bug in their repo:
  The pattern /^${SEARCH_FOR}/ only checks if a line starts with the search term.
   * If ${SEARCH_FOR} is Rate.XP.Kill, it matches Rate.XP.Kill.Vanilla.
   * The c command then replaces that entire line.
   * The result is that the expansion-specific settings are deleted and turned into duplicates of the global setting.